### PR TITLE
derive Clone on TermInfo struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod parsing;
 mod tests;
 
 /// Terminfo database information
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct TermInfo {
     pub name: String,
     pub description: String,
@@ -88,7 +88,7 @@ impl std::convert::From<FromUtf8Error> for Error {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct Extended {
     capabilities: HashMap<String, ValueStorage>,
     table: Box<[u8]>,
@@ -101,7 +101,7 @@ enum ValueStorage {
     Number(i32),
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct TermInfoData {
     bools: Box<[bool]>,
     numbers: Box<[i32]>,


### PR DESCRIPTION
This patch adds a clone derivation to the TermInfo struct. Deep copying is a pretty basic operation, especially in rust where it often makes sense to simplfy borrow checking issues by just paying for a few extra cycles, and not having the ability to clone makes the TermInfo type harder to work with.